### PR TITLE
accel-config: clean up resource leak

### DIFF
--- a/accfg/lib/libaccfg.c
+++ b/accfg/lib/libaccfg.c
@@ -2191,6 +2191,7 @@ static int accfg_wq_control(struct accfg_wq *wq, enum accfg_control_flag flag,
 		if (wq->driver_name && access(path, F_OK)) {
 			fprintf(stderr, "Invalid wq driver name \"%s\"\n",
 					wq->driver_name);
+			free(path);
 			return -ENOENT;
 		}
 	} else if (flag == ACCFG_WQ_DISABLE) {


### PR DESCRIPTION
In the error path for an invalid workqueue driver name, free
the path variable.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>