### PR TITLE
accel-config: test: Rename IAXTEST to IAATEST in test/common

### DIFF
--- a/test/common
+++ b/test/common
@@ -39,12 +39,12 @@ else
 	exit "$EXIT_FAILURE"
 fi
 
-# IAXTEST
+# IAATEST
 #
 if [ -f "./iaa_test" ] && [ -x "./iaa_test" ]; then
-	export IAXTEST=./iaa_test
+	export IAATEST=./iaa_test
 elif [ -f "$TESTDIR/iaa_test" ] && [ -x "$TESTDIR/iaa_test" ]; then
-	export IAXTEST="$TESTDIR"/iaa_test
+	export IAATEST="$TESTDIR"/iaa_test
 else
 	echo "Couldn't find an iaa_test binary"
 	exit "$EXIT_FAILURE"


### PR DESCRIPTION
The name changed, so update the variable to the correct name so that iaa_user_test_runner.sh can make use of it.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>