### PR TITLE
accel-config: Clean up memory leak, errouneous assignment, and unused path variable

### DIFF
--- a/accfg/lib/libaccfg.c
+++ b/accfg/lib/libaccfg.c
@@ -835,16 +835,16 @@ static void *add_wq(void *parent, int id, const char *wq_base,
 	wq->wq_buf = calloc(1, strlen(wq_base) + MAX_BUF_LEN);
 	if (!wq->wq_buf) {
 		err(ctx, "allocation of wq buffer failed\n");
-		goto err_read;
+		goto err_path;
 	}
 	wq->buf_len = strlen(wq_base) + MAX_BUF_LEN;
 
 	list_add_tail(&device->wqs, &wq->list);
 	return wq;
 
-err_read:
-	free(wq->wq_buf);
+err_path:
 	free(wq->wq_path);
+err_read:
 	free(wq->mode);
 	free(wq->state);
 	free(wq->name);
@@ -919,14 +919,15 @@ static void *add_group(void *parent, int id, const char *group_base,
 	group->group_path = strdup(group_base);
 	if (!group->group_path) {
 		err(ctx, "forming of group path failed\n");
-		goto err_read;
+		goto err_buf;
 	}
 
 	list_add_tail(&device->groups, &group->list);
 	return group;
 
-err_read:
+err_buf:
 	free(group->group_buf);
+err_read:
 	free(group->group_engines);
 	free(group->group_wqs);
 err_group:
@@ -965,15 +966,13 @@ static void *add_engine(void *parent, int id, const char *engine_base,
 	if (!engine_base_string) {
 		err(ctx, "conversion of engine_base_string failed\n");
 		close(dfd);
-		free(engine);
-		return NULL;
+		goto err_engine;
 	}
 	if (sscanf(basename(engine_base_string),
 			"engine%" SCNu64 ".%" SCNu64, &device_id, &engine_id) != 2) {
 		free(engine_base_string);
 		close(dfd);
-		free(engine);
-		return NULL;
+		goto err_engine;
 	}
 	free(engine_base_string);
 
@@ -986,22 +985,22 @@ static void *add_engine(void *parent, int id, const char *engine_base,
 	engine->engine_path = strdup(engine_base);
 	if (!engine->engine_path) {
 		err(ctx, "forming of engine path failed\n");
-		goto err_read;
+		goto err_engine;
 	}
 
 	engine->engine_buf = calloc(1, strlen(engine_base) + MAX_BUF_LEN);
 	if (!engine->engine_buf) {
 		err(ctx, "allocation of engine buffer failed\n");
-		goto err_read;
+		goto err_path;
 	}
 	engine->buf_len = strlen(engine_base) + MAX_BUF_LEN;
 
 	list_add_tail(&device->engines, &engine->list);
 	return engine;
 
-err_read:
-	free(engine->engine_buf);
+err_path:
 	free(engine->engine_path);
+err_engine:
 	free(engine);
 	return NULL;
 }

--- a/accfg/lib/libaccfg.c
+++ b/accfg/lib/libaccfg.c
@@ -767,7 +767,6 @@ static void *add_wq(void *parent, int id, const char *wq_base,
 	struct accfg_device *device = parent;
 	struct accfg_group *group;
 	struct accfg_ctx *ctx;
-	char *path;
 	char *wq_base_string;
 	uint64_t device_id, wq_id;
 	int dfd;
@@ -782,18 +781,10 @@ static void *add_wq(void *parent, int id, const char *wq_base,
 	if (dfd < 0)
 		return NULL;
 
-	path = calloc(1, strlen(wq_base) + 100);
-	if (!path) {
-		err(ctx, "%s: allocation of path failed\n", __func__);
-		close(dfd);
-		return NULL;
-	}
-
 	wq = calloc(1, sizeof(*wq));
 	if (!wq) {
 		err(ctx, "allocation of wq failed\n");
 		close(dfd);
-		free(path);
 		return NULL;
 	}
 
@@ -849,7 +840,6 @@ static void *add_wq(void *parent, int id, const char *wq_base,
 	wq->buf_len = strlen(wq_base) + MAX_BUF_LEN;
 
 	list_add_tail(&device->wqs, &wq->list);
-	free(path);
 	return wq;
 
 err_read:
@@ -860,7 +850,6 @@ err_read:
 	free(wq->name);
 err_wq:
 	free(wq);
-	free(path);
 	return NULL;
 }
 
@@ -870,7 +859,6 @@ static void *add_group(void *parent, int id, const char *group_base,
 	struct accfg_group *group;
 	struct accfg_device *device = parent;
 	struct accfg_ctx *ctx;
-	char *path;
 	char *group_base_string;
 	int dfd;
 	uint64_t device_id, group_id;
@@ -883,17 +871,11 @@ static void *add_group(void *parent, int id, const char *group_base,
 	if (dfd < 0)
 		return NULL;
 
-	path = calloc(1, strlen(group_base) + 100);
-	if (!path) {
-		err(ctx, "%s: allocation of path failed\n", __func__);
-		close(dfd);
-		return NULL;
-	}
 	group = calloc(1, sizeof(*group));
 	if (!group) {
 		err(ctx, "allocation of group failed\n");
 		close(dfd);
-		goto err_group;
+		return NULL;
 	}
 
 	group_base_string = strdup(group_base);
@@ -941,7 +923,6 @@ static void *add_group(void *parent, int id, const char *group_base,
 	}
 
 	list_add_tail(&device->groups, &group->list);
-	free(path);
 	return group;
 
 err_read:
@@ -950,7 +931,6 @@ err_read:
 	free(group->group_wqs);
 err_group:
 	free(group);
-	free(path);
 	return NULL;
 }
 
@@ -961,7 +941,6 @@ static void *add_engine(void *parent, int id, const char *engine_base,
 	struct accfg_device *device = parent;
 	struct accfg_ctx *ctx;
 	struct accfg_group *group;
-	char *path;
 	char *engine_base_string;
 	int dfd;
 	uint64_t device_id, engine_id;
@@ -975,18 +954,11 @@ static void *add_engine(void *parent, int id, const char *engine_base,
 	if (dfd < 0)
 		return NULL;
 
-	path = calloc(1, strlen(engine_base) + 100);
-	if (!path) {
-		err(ctx, "%s: allocation of path failed\n", __func__);
-		close(dfd);
-		return NULL;
-	}
-
 	engine = calloc(1, sizeof(*engine));
 	if (!engine) {
 		err(ctx, "allocation of engine failed\n");
 		close(dfd);
-		goto err_engine;
+		return NULL;
 	}
 
 	engine_base_string = strdup(engine_base);
@@ -994,13 +966,12 @@ static void *add_engine(void *parent, int id, const char *engine_base,
 		err(ctx, "conversion of engine_base_string failed\n");
 		close(dfd);
 		free(engine);
-		goto err_engine;
+		return NULL;
 	}
 	if (sscanf(basename(engine_base_string),
 			"engine%" SCNu64 ".%" SCNu64, &device_id, &engine_id) != 2) {
 		free(engine_base_string);
 		close(dfd);
-		free(path);
 		free(engine);
 		return NULL;
 	}
@@ -1026,15 +997,12 @@ static void *add_engine(void *parent, int id, const char *engine_base,
 	engine->buf_len = strlen(engine_base) + MAX_BUF_LEN;
 
 	list_add_tail(&device->engines, &engine->list);
-	free(path);
 	return engine;
 
 err_read:
 	free(engine->engine_buf);
 	free(engine->engine_path);
 	free(engine);
-err_engine:
-	free(path);
 	return NULL;
 }
 

--- a/accfg/lib/libaccfg.c
+++ b/accfg/lib/libaccfg.c
@@ -910,7 +910,6 @@ static void *add_group(void *parent, int id, const char *group_base,
 	}
 	free(group_base_string);
 
-	group->group_path = (char *)group_base;
 	group->device = device;
 	device->group = group;
 	group->id = group_id;

--- a/accfg/test.c
+++ b/accfg/test.c
@@ -46,6 +46,7 @@ int cmd_test(int argc, const char **argv, struct accfg_ctx *ctx)
 	printf("run test_libaccfg\n");
 	rc = test_libaccfg(loglevel, test, ctx);
 	fprintf(stderr, "test-libaccfg: %s\n", result(rc));
+	free(test);
 	if (rc)
 		return rc;
 	printf("SUCCESS!\n");


### PR DESCRIPTION
The following pattern occurs with wq_base, group_base, and engine_base in accfg/lib/libaccfg.c:

    // Where X is one of: wq, group, engine
    X_base_string = strdup(X_base);
    sscanf(X_base_string,...);
    ...
    X->X_path = strdup(X_base);

    and X_base_string is never cleaned up with free().

Instead of calling strdup() twice, just assign X_base_string to X->X_path, clean up the error checking related to the 2nd strdup(), and make the error path clean up more consistent between the cases.

Also a really minor clean up of test in accfg/test.c, so covscan stops complaining about it.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>