### PR TITLE
idxd-config: Update spec file templates to use SPDX identifiers

### DIFF
--- a/accfg-test.spec.in
+++ b/accfg-test.spec.in
@@ -2,7 +2,7 @@ Name:		accel-config
 Version:	VERSION
 Release:	2%{?dist}
 Summary:	Configure accelerator subsystem devices
-License:	GPLv2
+License:	GPL-2.0
 Group:		System Environment/Base
 Source0:	%{name}-%{version}.tar.gz
 
@@ -22,7 +22,7 @@ Utility library for configuring the accelerator subsystem.
 
 %package -n DNAME
 Summary:	Development files for libaccfg
-License:	LGPLv2.1
+License:	LGPL-2.1-only
 Group:		Development/Libraries
 Requires:	LNAME%{?_isa} = %{version}-%{release}
 
@@ -33,7 +33,7 @@ developing applications that use %{name}.
 
 %package -n LNAME
 Summary:	Configuration library for accelerator subsystem devices
-License:	LGPLv2.1
+License:	LGPL-2.1-only
 Group:		System Environment/Libraries
 
 %description -n LNAME
@@ -41,7 +41,7 @@ Libraries for %{name}.
 
 %package -n %{name}-test
 Summary:	Unit tests for %{name}.
-License:	GPLv2
+License:	GPL-2.0
 Group:		Unspecified
 
 %description -n %{name}-test

--- a/accfg.spec.in
+++ b/accfg.spec.in
@@ -2,7 +2,7 @@ Name:		accel-config
 Version:	VERSION
 Release:	2%{?dist}
 Summary:	Configure accelerator subsystem devices
-License:	GPLv2
+License:	GPL-2.0
 Group:		System Environment/Base
 Source0:	%{name}-%{version}.tar.gz
 
@@ -22,7 +22,7 @@ Utility library for configuring the accelerator subsystem.
 
 %package -n DNAME
 Summary:	Development files for libaccfg
-License:	LGPLv2.1
+License:	LGPL-2.1-only
 Group:		Development/Libraries
 Requires:	LNAME%{?_isa} = %{version}-%{release}
 
@@ -33,7 +33,7 @@ developing applications that use %{name}.
 
 %package -n LNAME
 Summary:	Configuration library for accelerator subsystem devices
-License:	LGPLv2.1
+License:	LGPL-2.1-only
 Group:		System Environment/Libraries
 
 %description -n LNAME


### PR DESCRIPTION
Update License fields in spec file templates to use SPDX identifiers for license names.