### PR TITLE
Add version macros in libaccel_config.h

### DIFF
--- a/accfg/libaccel_config.h
+++ b/accfg/libaccel_config.h
@@ -16,6 +16,10 @@
 extern "C" {
 #endif
 
+#define ACCFG_VERSION_MAJOR 4
+#define ACCFG_VERSION_MINOR 0
+#define ACCFG_VERSION_PATCH 0
+
 #ifndef UUID_STR_LEN
 #define UUID_STR_LEN 37
 #endif


### PR DESCRIPTION
This PR adds VERSION macros in libaccel_config.h. 
These version macros will be useful to developers using accel-config (e.g. QPL/DML developers) in the following case:
If a new API is introduced in version A of accel-config, we can use the version macro as preprocessor macro to conditionally compile the code whether the new API is used. This avoids getting "undefined symbol" error with versions earlier than A.

Possible workarounds and why we prefer adding VERSION macros:
1. Always request end users to update to latest version of accel-config: This is not preferred because it's unnecessary for users who are staying with older hardware to update the accel-config driver to latest. For example, current users are using QPL on SPR with accel-config v3.5. But they will face issue when they upgrade to QPL v1.2 (which will start using `accfg_device_get_iaa_cap`, an API added in accel-config v4.0). For such customers who are staying with SPR and not migrating to GNR, we should avoid requesting them to upgrade accel-config unless necessary.
2. Use `accfg_device_get_version` to check HW gen2 features: this is the least preferred option since it's not guaranteed that the device version always imply certain features are present. It's safer to use the officially supported way (checking IAACAP)

In this PR, the version macros are hardcoded and they will need to be updated before each official release. I'm open to other approaches besides hardcoding them. But I see that there's another "version" hardcoded in git-version being updated for each release https://github.com/intel/idxd-config/blob/stable/git-version#L22