### PR TITLE
Minor Debian packaging updates

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: accel-config
 Maintainer: Ramesh Thomas <ramesh.thomas@intel.com>
 Section: libs
 Priority: optional
-Standards-Version: 4.6.1.0
+Standards-Version: 4.6.2
 Homepage: https://github.com/intel/idxd-config
 Vcs-Browser: https://salsa.debian.org/debian/idxd-config
 Vcs-Git: https://salsa.debian.org/debian/idxd-config.git

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,5 @@
+version=4
+opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%@PACKAGE@-$1.tar.gz%" \
+             https://github.com/intel/idxd-config/tags \
+             (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate
+

--- a/test/iaa.c
+++ b/test/iaa.c
@@ -1872,7 +1872,7 @@ int iaa_transl_fetch_multi_task_nodes(struct acctest_context *ctx, int do_mmap)
 			return -errno;
 		}
 
-		__builtin_ia32_mfence();
+		__asm__ __volatile__ ("mfence" ::: "memory");
 
 		tsk_node = tsk_node->next;
 	}


### PR DESCRIPTION
Two minor Debian packaging updates, one to update to the latest standards version, another to add a watch file to keep track of latest github release tags