### PR TITLE
Fixing memory leak by freeing memory allocated by scandir()

### DIFF
--- a/util/sysfs.c
+++ b/util/sysfs.c
@@ -95,6 +95,8 @@ int __sysfs_device_parse(struct log_ctx *ctx, const char *base_path,
 
 		de = d[i];
 		if (sscanf(de->d_name, "%*[a-z]%d", &id) < 0) {
+			while(n--)
+				free(d[n]);
 			free(d);
 			return -EINVAL;
 		}
@@ -113,6 +115,8 @@ int __sysfs_device_parse(struct log_ctx *ctx, const char *base_path,
 		} else
 			log_dbg(ctx, "%d: processed\n", id);
 	}
+	while(n--)
+		free(d[n]);
 	free(d);
 
 	return add_errors;


### PR DESCRIPTION
### Background
According to the `scandir()` [manual page](https://man7.org/linux/man-pages/man3/scandir.3.html#DESCRIPTION)
> The scandir() function scans the directory dirp, calling filter()
       on each directory entry.  Entries for which filter() returns
       nonzero are stored in strings allocated via [malloc(3)](https://man7.org/linux/man-pages/man3/malloc.3.html), sorted
       using [qsort(3)](https://man7.org/linux/man-pages/man3/qsort.3.html) with the comparison function compar(), and
       collected in array namelist which is allocated via [malloc(3)](https://man7.org/linux/man-pages/man3/malloc.3.html).  If
       filter is NULL, all entries are selected.


Using the same syntax for freeing as found here: 
https://github.com/intel/idxd-config/blob/435fa62bca9bd64069f7d816eae44b7bcc63f3bb/accfg/lib/libaccfg.c#L2249-L2251

### Testing

![image](https://github.com/intel/idxd-config/assets/25994682/ec3647c2-3c20-412e-8178-c269f9cfb149)


Output of DML with memory-sanitizer
Before change:
![image](https://github.com/intel/idxd-config/assets/25994682/57bc3e11-6a83-4bf1-8ca8-907936448cce)

After change:
![image](https://github.com/intel/idxd-config/assets/25994682/f927cdde-7f5a-4555-863f-353e34ed4ef8)
