### PR TITLE
Free driver_name in case of early exit

### DIFF
--- a/accfg/lib/libaccfg.c
+++ b/accfg/lib/libaccfg.c
@@ -734,6 +734,7 @@ err_read:
 	free(wq->mode);
 	free(wq->state);
 	free(wq->name);
+	free(wq->driver_name);
 err_wq:
 	free(wq);
 	return NULL;


### PR DESCRIPTION
**Description:**
A small fix, it appears that `wq->driver_name` is dynamically allocated via `strdup` in `accfg_get_param_str`, but never gets properly freed alongside similar variables (e.g. mode, state, name) when there is an error. This would cause a small memory leak when this variable isn't freed. This PR adds that small fix that frees this variable and ensures no memory leak would occur. 