### PR TITLE
Fixing memory leak by freeing driver_name in free_wq function

### DIFF
--- a/accfg/lib/libaccfg.c
+++ b/accfg/lib/libaccfg.c
@@ -276,6 +276,7 @@ static void free_wq(struct accfg_wq *wq)
 	free(wq->mode);
 	free(wq->state);
 	free(wq->name);
+	free(wq->driver_name);
 	free(wq);
 }
 


### PR DESCRIPTION
### Background

Found in QPL memory sanitizer check. Adding a missed free-ing of `wq->driver_name` in `free_wq()` function

### Testing
Before Changes:
![image](https://github.com/intel/idxd-config/assets/25994682/c6c7cc19-79b0-474c-af96-0fe78ede1c8a)


After Changes:
![image](https://github.com/intel/idxd-config/assets/25994682/150db671-aeb0-42f0-b8da-fff2f2060408)
