### PR TITLE
accel-config/test: Check whether any devices of a type exist

### DIFF
--- a/test/common
+++ b/test/common
@@ -122,12 +122,18 @@ check_prereq()
 disable_all() {
   for device_type in 'dsa' 'iax'; do
     # Kernel before 5.13 has dsa and iax bus. Because of ABI change, iax
-    # bus is removed. All devices are in /sys/bus/das/devices.
+    # bus is removed. All devices are in /sys/bus/dsa/devices.
     if [ -d /sys/bus/iax ] && [ $device_type == 'iax' ]; then
       DSA_DEVICE_PATH="/sys/bus/iax/devices"
     else
       DSA_DEVICE_PATH="/sys/bus/dsa/devices"
     fi
+
+    # Check whether any devices exist of this type
+    if [ ! -d ${DSA_DEVICE_PATH}/${device_type}* ]; then
+	continue
+    fi
+
 	# Get available devices
     for device_path in ${DSA_DEVICE_PATH}/${device_type}* ; do
       [[ $(echo "$device_path" | grep -c '!') -eq 0 ]] && {


### PR DESCRIPTION
If no devices exist for a certain type, then skip trying to loop through disabling them. This avoids dsa_user_test_runner.sh failing with an error on a system with no iax devices.