### PR TITLE
accel-config: Fix issues reported by coverity scan

### DIFF
--- a/accfg/lib/libaccfg.c
+++ b/accfg/lib/libaccfg.c
@@ -1919,6 +1919,7 @@ ACCFG_EXPORT uint64_t accfg_wq_get_max_transfer_size(struct accfg_wq *wq)
 
 ACCFG_EXPORT int accfg_wq_get_occupancy(struct accfg_wq *wq)
 {
+	long occ;
 	int dfd;
 	struct accfg_ctx *ctx = accfg_wq_get_ctx(wq);
 
@@ -1926,7 +1927,9 @@ ACCFG_EXPORT int accfg_wq_get_occupancy(struct accfg_wq *wq)
 	if (dfd < 0)
 		return -ENXIO;
 
-	return accfg_get_param_long(ctx, dfd, "occupancy");
+	occ = accfg_get_param_long(ctx, dfd, "occupancy");
+	close(dfd);
+	return occ;
 }
 
 ACCFG_EXPORT int accfg_wq_get_clients(struct accfg_wq *wq)

--- a/test/iaa.c
+++ b/test/iaa.c
@@ -2625,6 +2625,10 @@ int task_result_verify_encrypto(struct task *tsk, int mismatch_expected)
 				     (uint8_t *)iaa_crypto_aecs->aes_key_low,
 				     (uint8_t *)iaa_crypto_aecs->counter_iv,
 				     key_size, iaa_crypto_aecs->crypto_algorithm, 1);
+	if (expected_len < 0) {
+		err("iaa_do_crypto returned: %d\n", expected_len);
+		return -ENXIO;
+	}
 	rc = memcmp(tsk->dst1, tsk->output, expected_len);
 
 	if (!mismatch_expected) {
@@ -2673,6 +2677,10 @@ int task_result_verify_decrypto(struct task *tsk, int mismatch_expected)
 				     (uint8_t *)iaa_crypto_aecs->aes_key_low,
 				     (uint8_t *)iaa_crypto_aecs->counter_iv,
 				     key_size, iaa_crypto_aecs->crypto_algorithm, 0);
+	if (expected_len < 0) {
+		err("iaa_do_crypto returned: %d\n", expected_len);
+		return -ENXIO;
+	}
 	rc = memcmp(tsk->dst1, tsk->output, expected_len);
 
 	if (!mismatch_expected) {


### PR DESCRIPTION
It is possible for iaa_do_crypto to return an error value so the returned value should be checked when it is called. memcmp expects a size_t for the number of bytes to compare, which is an unsigned integer. If an error value is returned by iaa_do_crypto, this results in calling memcmp with a rather large size as the negative value is converted to a size_t. This was detected by OpenScanHub service that runs when an official build of a package is submitted.

Signed-off-by: Jerry Snitselaar <jsnitsel@redhat.com>