### PR TITLE
Update dsa_config_test_runner.sh

### DIFF
--- a/test/dsa_config_test_runner.sh
+++ b/test/dsa_config_test_runner.sh
@@ -145,6 +145,8 @@ wq_config_test()
 	if [ "$IDXD_VERSION" != "0x100" ]; then
 		[ ! -f "$IDXD_DEVICE_PATH/$DSA/$WQ0/op_config" ] && exit 1
 
+		op_cap="$(cat $IDXD_DEVICE_PATH/$DSA/$WQ0/op_config | cut -c 55-)"
+  
 		echo 0 > "$IDXD_DEVICE_PATH/$DSA/$WQ0/op_config"
 		read_ret=$(cat $IDXD_DEVICE_PATH/$DSA/$WQ0/op_config | cut -c 55-)
 		if [ "$read_ret" != "00000000,00000000"	]; then
@@ -164,9 +166,9 @@ wq_config_test()
 			echo "config wq op_config failed" && exit "$EXIT_FAILURE"
 		fi
 
-		"$ACCFG" config-wq $DSA/$WQ0 --op-config=0000007b,00bf07ff || exit 1
+		"$ACCFG" config-wq $DSA/$WQ0 --op-config="${op_cap}" || exit 1
 		read_ret=$(cat $IDXD_DEVICE_PATH/$DSA/$WQ0/op_config | cut -c 55-)
-		if [ "$read_ret" != "0000007b,00bf07ff" ]; then
+		if [ "$read_ret" != "${op_cap}" ]; then
 			echo "config wq full operations failed" && exit "$EXIT_FAILURE"
 		fi
 


### PR DESCRIPTION
More and more Intel processors will support DSA(Data Streaming Accelerator), but the operation capability won't always be "0000007b,00bf07ff". Below is an example on the processor "INTEL(R) XEON(R) SIERRA FOREST A0 108MB 144c 320W": $ sudo cat /sys/bus/dsa/devices/dsa0/wq0.0/op_config
  00000000,00000000,00000000,00000000,00000000,00000000,0000007b,00bf067f

To better support full operation testing on different CPUs, it'd better to setup the op_config by using variables instead of constants.

Signed-off-by: shangsong <shangsong2@lenovo.com>