### PR TITLE
accel-config: Add three options for sub-command disable-device And a Sub-command 'info'

### DIFF
--- a/Documentation/accfg/Makefile.am
+++ b/Documentation/accfg/Makefile.am
@@ -30,7 +30,8 @@ man1_MANS = \
 	accel-config-disable-wq.1 \
 	accel-config-enable-wq.1 \
 	accel-config-enable-device.1 \
-	accel-config-config-user-default.1
+	accel-config-config-user-default.1 \
+	accel-config-info.1
 
 EXTRA_DIST = \
 	$(man1_MANS) \
@@ -46,7 +47,8 @@ EXTRA_DIST = \
 	accel-config-disable-wq.txt \
 	accel-config-enable-wq.txt \
 	accel-config-enable-device.txt \
-	accel-config-config-user-default.txt
+	accel-config-config-user-default.txt \
+	accel-config-info.txt
 
 CLEANFILES = $(man1_MANS)
 

--- a/Documentation/accfg/accel-config-disable-device.txt
+++ b/Documentation/accfg/accel-config-disable-device.txt
@@ -11,10 +11,15 @@ SYNOPSIS
 --------
 [verse]
 'accel-config disable-device' <device>
+'accel-config disable-device' <device-type>
+	dsa: disable all DSA devices
+	iax: disable all IAX devices
+	all: disable all devices
 
 EXAMPLE
 -------
 accel-config disable-device dsa0
+accel-config disable-device all
 
 OPTIONS
 -------

--- a/Documentation/accfg/accel-config-enable-device.txt
+++ b/Documentation/accfg/accel-config-enable-device.txt
@@ -11,10 +11,15 @@ SYNOPSIS
 --------
 [verse]
 'accel-config enable-device' <device>
+'accel-config enable-device' <device-type>
+	dsa: enable all configured DSA devices
+	iax: enable all configured IAX devices
+	all: enable all configured devices
 
 EXAMPLE
 -------
 accel-config enable-device dsa0
+accel-config enable-device all
 
 include::../copyright.txt[]
 

--- a/Documentation/accfg/accel-config-info.txt
+++ b/Documentation/accfg/accel-config-info.txt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0
+
+accel-config info(1)
+====================
+
+NAME
+----
+accel-config-info - dump more idxd device information.
+
+SYNOPSIS
+--------
+[verse]
+'accel-config info [-v]'
+
+EXAMPLE
+-------
+accel-config info -v
+
+dsa0 [active]
+
+00000000,00000000,00000000,00000000,00000000,00000000,0000007b,00bf07fd
+
+Batch[-] Drain[+] Memory Move[+] Fill[+] Compare[+] Compare Pattern[+] Create Delta Record[+] Apply Delta Record[+] Memory Copy with Dualcast[+] Translation Fetch[+] CRC Generation[+] Copy with CRC Generation[+] DIF Check[+] DIF Insert[+] DIF Strip[+] DIF Update[+] DIX Generate[+] Cache Flush[+] Update Window[+] Inter-Domain Momery Copy[+] Inter-Domain Fill[+] Inter-Domain Compare[+] Inter-Domain Compare Pattern[+] Inter-Domain Cache Flush[-]
+
+iax1
+
+00000000,00000000,00000000,00000000,00000000,004d001c,00000000,00000405
+
+Drain[+] Translation Fetch[+] Decrypt[-] Encrypt[-] Decompress[+] Compress[+] CRC64[+] Zdecompress32[-] Zdecompress16[-] Zdecompress8 [-] Zcompress32[-] Zcompress16[-] Zcompress8[-] Scan[+] Set Membership[-] Extract[+] Select[+] BLE Burst[-] Find Unique[-] Expand[+]
+
+OPTIONS
+-------
+-v:
+	Verbose mode. Print more information about the device.
+
+include::../copyright.txt[]
+
+SEE ALSO
+--------
+accel-config info(1)

--- a/accfg/accel-config.c
+++ b/accfg/accel-config.c
@@ -23,6 +23,7 @@ const char accfg_usage_string[] =
 
 static struct cmd_struct commands[] = {
 	{"list", cmd_list},
+	{"info", cmd_info},
 	{"load-config", cmd_config},
 	{"save-config",  cmd_save},
 	{"disable-device", cmd_disable_device},

--- a/accfg/enable.c
+++ b/accfg/enable.c
@@ -96,7 +96,7 @@ static int device_action(int argc, const char **argv, const char *usage,
 		NULL
 	};
 	int i, rc = -EINVAL, success = 0;
-	enum accfg_device_state state;
+	enum accfg_device_state;
 	struct accfg_device *device = NULL;
 	unsigned int bmap_dev = 0;
 
@@ -155,18 +155,6 @@ static int device_action(int argc, const char **argv, const char *usage,
 		}
 
 		rc = dev_action_switch(device, action);
-		if (rc == 0) {
-			/*
-			 * Double check if the state of the device
-			 * matches with the enable/disable
-			 */
-			state = accfg_device_get_state(device);
-			if (((state != ACCFG_DEVICE_ENABLED) &&
-					(action == DEV_ACTION_ENABLE)) ||
-					((state != ACCFG_DEVICE_DISABLED) &&
-					(action == DEV_ACTION_DISABLE)))
-				rc = ENXIO;
-		}
 		if (rc == 0)
 			success++;
 		else
@@ -180,7 +168,7 @@ static int device_action(int argc, const char **argv, const char *usage,
 	if (success)
 		return 0;
 
-	return rc;
+	return -ENXIO;
 }
 
 static int action_disable_wq(struct accfg_wq *wq, const char *wq_name)

--- a/accfg/enable.c
+++ b/accfg/enable.c
@@ -285,7 +285,13 @@ static int wq_action(int argc, const char **argv, const char *usage,
 int cmd_disable_device(int argc, const char **argv, void *ctx)
 {
 	char *usage =
-	    "accel-config disable-device <accel_basename0> [<accel_basename1>..<accel_basenameN>] [<options>]";
+	    "\naccel-config disable-device <accel_basename0> [<accel_basename1>..<accel_basenameN>] [<options>]\n"
+	    "accel-config disable-device <device type>\n"
+	    "    device_type: can be one of following values\n"
+	    "        dsa: disable all DSA devices\n"
+	    "        iax: disable all IAX devices\n"
+	    "        all: disable all devices\n";
+
 	int count = device_action(argc, argv, usage, device_disable_options,
 				  DEV_ACTION_DISABLE, ctx);
 	return count >= 0 ? 0 : EXIT_FAILURE;
@@ -294,7 +300,13 @@ int cmd_disable_device(int argc, const char **argv, void *ctx)
 int cmd_enable_device(int argc, const char **argv, void *ctx)
 {
 	char *usage =
-	    "accel-config enable-device <accel_basename0> [<accel_basename1>..<accel_basenameN>] [<options>]";
+	    "\naccel-config enable-device <accel_basename0> [<accel_basename1>..<accel_basenameN>] [<options>]\n"
+	    "accel-config enable-device <device type>\n"
+	    "    device_type: can be one of following values\n"
+	    "        dsa: enable all configured DSA devices\n"
+	    "        iax: enable all configured IAX devices\n"
+	    "        all: enable all configured devices\n";
+
 	int count = device_action(argc, argv, usage, device_options,
 				  DEV_ACTION_ENABLE, ctx);
 	return count >= 0 ? 0 : EXIT_FAILURE;

--- a/builtin.h
+++ b/builtin.h
@@ -19,6 +19,7 @@ struct cmd_struct {
 	int (*fn) (int, const char **, void *ctx);
 };
 int cmd_list(int argc, const char **argv, void *ctx);
+int cmd_info(int argc, const char **argv, void *ctx);
 int cmd_config(int argc, const char **argv, void *ctx);
 int cmd_save(int argc, const char **argv, void *ctx);
 int cmd_disable_device(int argc, const char **argv, void *ctx);


### PR DESCRIPTION
accel-config: Add a subcommand info
List all available DSA/IAX devices and their status.
e.g.
```
$ sudo accel-config info
dsa0 (Active!)
dsa2
```

accel-config: Add three options for sub-command disable-device
For certain reasons, the user needs to disable all configured devices,
or IAA or DSA seperatedly. Previously, the user would repeatedly call the
'disable-device' sub-command in a loop. The newly added 'all' 'dsa'
'iax' options for 'disable-device' offers a more convenient solution.
