### PR TITLE
Change some file licenses to match original licenses

### DIFF
--- a/util/log.c
+++ b/util/log.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1 */
-/* Copyright(c) 2016-2019 Intel Corporation. All rights reserved. */
+/* Copyright(c) 2016-2025 Intel Corporation. All rights reserved. */
 
 #include <syslog.h>
 #include <stdlib.h>

--- a/util/log.c
+++ b/util/log.c
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2015-2019 Intel Corporation. All rights reserved. */
+/* SPDX-License-Identifier: LGPL-2.1 */
+/* Copyright(c) 2016-2019 Intel Corporation. All rights reserved. */
 
 #include <syslog.h>
 #include <stdlib.h>

--- a/util/log.h
+++ b/util/log.h
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2015-2019 Intel Corporation. All rights reserved. */
+/* SPDX-License-Identifier: LGPL-2.1 */
+/* Copyright(c) 2016-2019 Intel Corporation. All rights reserved. */
 
 #ifndef __UTIL_LOG_H__
 #define __UTIL_LOG_H__

--- a/util/log.h
+++ b/util/log.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1 */
-/* Copyright(c) 2016-2019 Intel Corporation. All rights reserved. */
+/* Copyright(c) 2016-2025 Intel Corporation. All rights reserved. */
 
 #ifndef __UTIL_LOG_H__
 #define __UTIL_LOG_H__

--- a/util/sysfs.c
+++ b/util/sysfs.c
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2015-2019 Intel Corporation. All rights reserved. */
+/* SPDX-License-Identifier: LGPL-2.1 */
+/* Copyright(c) 2014-2019 Intel Corporation. All rights reserved. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/util/sysfs.c
+++ b/util/sysfs.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1 */
-/* Copyright(c) 2014-2019 Intel Corporation. All rights reserved. */
+/* Copyright(c) 2014-2025 Intel Corporation. All rights reserved. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/util/sysfs.h
+++ b/util/sysfs.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1 */
-/* Copyright(c) 2014-2019 Intel Corporation. All rights reserved. */
+/* Copyright(c) 2014-2025 Intel Corporation. All rights reserved. */
 
 #ifndef __UTIL_SYSFS_H__
 #define __UTIL_SYSFS_H__

--- a/util/sysfs.h
+++ b/util/sysfs.h
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: GPL-2.0 */
-/* Copyright(c) 2015-2019 Intel Corporation. All rights reserved. */
+/* SPDX-License-Identifier: LGPL-2.1 */
+/* Copyright(c) 2014-2019 Intel Corporation. All rights reserved. */
 
 #ifndef __UTIL_SYSFS_H__
 #define __UTIL_SYSFS_H__


### PR DESCRIPTION
Changing some license that were slightly modified in this commit: https://github.com/intel/idxd-config/commit/65a019d686da69a7a82bd4bc8e0bac9adc38406e#diff-3ddb08a7ce9260e61cf568dc28cef5f66d0a15753b6ef5cc25db0c947e948dff

Changes are for files that had the LGPL-2.1 license, then were changed to the GPL license. 

Double checked these files in pmem/ndctl, and they all have the LGPL license there as well.
https://github.com/pmem/ndctl/blob/04815e5f8b87e02a4fb5a61aeebaa5cad25a15c3/util/log.h#L1-L2
https://github.com/pmem/ndctl/blob/04815e5f8b87e02a4fb5a61aeebaa5cad25a15c3/util/sysfs.h#L1-L2


Also changed the start date that was changed in the commit, original licenses had a different start date.

Let me know if I should revert the dates back, as I'm not entirely sure if there was a reason to change those dates as well.