### PR TITLE
contrib/configs/profilenote.txt: Fix spelling mistake "Calcuated" -> "Calculated"

### DIFF
--- a/contrib/configs/profilenote.txt
+++ b/contrib/configs/profilenote.txt
@@ -51,7 +51,7 @@ profile descriptions.
               "ats_disable":0
               "prs_disable":1
               "name":"user_default_wq"
-            - Calcuated attributes:
+            - Calculated attributes:
               "size": max WQ size / max WQs
               "threshold": WQ size
             - Fixed attributes:


### PR DESCRIPTION
There is a spelling mistake, fix it.