### PR TITLE
Fix null setting of jc->jgroup_assigned

### DIFF
--- a/accfg/config.c
+++ b/accfg/config.c
@@ -1112,7 +1112,6 @@ static bool filter_device(struct accfg_device *device,
 	jc->jgroup_assigned = calloc(max_groups,
 			sizeof(struct json_object *));
 
-	jc->jgroup_assigned = NULL;
 	jc->jwq_group = NULL;
 	jc->jengine_group = NULL;
 


### PR DESCRIPTION
The pointer jc->jgroup_assigned is being assigned a NULL immediately after it was assigned the return from a calloc call. This is incorrect, it causes a memory leak and causes the filter_device function to fail. Fix this by removing this erroneous statement.

Fixes: ac8294cc815b ("static-analysis: Fix coverity memory leak issues")